### PR TITLE
Fix orbit.js build issue with localforage load

### DIFF
--- a/lib/orbit-common/local-forage-source.js
+++ b/lib/orbit-common/local-forage-source.js
@@ -61,7 +61,7 @@ var LocalForageSource = MemorySource.extend({
     return new Orbit.Promise(function(resolve, reject) {
       _this.localforage.getItem(_this.namespace).then(function(storage){
         if (storage) {
-          _this.reset(Orbit.default.extend(_this.retrieve(), storage));
+          _this.reset(Orbit.extend(_this.retrieve(), storage));
         }
         resolve();
       });


### PR DESCRIPTION
- build process appended `default` twice
